### PR TITLE
Harden deploy endpoint by removing shell command chaining

### DIFF
--- a/server.py
+++ b/server.py
@@ -1248,11 +1248,42 @@ def api_term_kill(task_id):
 def api_deploy():
     try:
         # Git deploy
-        result = subprocess.run('git add . && git commit -m "v2.0: Integrated C2 Controls, Auto-Port Recovery, Claude-Bug-Bounty Logic" || true && git push origin HEAD', shell=True, capture_output=True, text=True, cwd=str(ROOT), timeout=60)
-        if result.returncode == 0:
-            return jsonify({"ok": True, "output": result.stdout})
-        else:
-            return jsonify({"ok": False, "error": result.stderr}), 500
+        add_result = subprocess.run(
+            ["git", "add", "."],
+            capture_output=True,
+            text=True,
+            cwd=str(ROOT),
+            timeout=30,
+        )
+        if add_result.returncode != 0:
+            return jsonify({"ok": False, "error": add_result.stderr}), 500
+
+        commit_result = subprocess.run(
+            [
+                "git",
+                "commit",
+                "-m",
+                "v2.0: Integrated C2 Controls, Auto-Port Recovery, Claude-Bug-Bounty Logic",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(ROOT),
+            timeout=30,
+        )
+        # No changes to commit is non-fatal; continue to push.
+        if commit_result.returncode != 0 and "nothing to commit" not in (commit_result.stdout + commit_result.stderr).lower():
+            return jsonify({"ok": False, "error": commit_result.stderr}), 500
+
+        push_result = subprocess.run(
+            ["git", "push", "origin", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=str(ROOT),
+            timeout=60,
+        )
+        if push_result.returncode == 0:
+            return jsonify({"ok": True, "output": push_result.stdout})
+        return jsonify({"ok": False, "error": push_result.stderr}), 500
     except Exception as exc:
         return jsonify({"ok": False, "error": str(exc)}), 502
 


### PR DESCRIPTION
### Motivation
- Reduce command-injection risk and eliminate use of `shell=True` for a multi-command deploy flow.
- Improve observability and error granularity for each git step so failures are easier to diagnose.
- Preserve existing behavior where "no changes to commit" is non-fatal and should still attempt a push.

### Description
- Replaced a single chained shell invocation with three explicit `subprocess.run` calls for `git add`, `git commit`, and `git push` in the `/api/deploy` handler.
- Each subprocess call uses argument lists, `capture_output=True`, `text=True`, a `cwd` pointing to `ROOT`, and individual `timeout` values for safer execution.
- Treats a non-zero commit return as acceptable when the combined stdout/stderr contains "nothing to commit", and returns precise error messages for failing add/commit/push steps.
- Wrapped the sequence in the existing try/except to maintain API error semantics.

### Testing
- Ran `python -m compileall -q server.py` and it completed successfully.
- Ran `python -m py_compile server.py` and the file compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa873480dc832e9cbcb419da7ea40b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment process with enhanced error handling for edge cases where no changes exist.
  * Clarified error reporting during deployment with more detailed failure diagnostics for each step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->