### PR TITLE
docs: add dashboard startup fallback via server.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The repository includes a **Flask + Socket.IO** web UI (`ui/index.html`, `server
 zwanski start
 ```
 
+If the CLI shim is unavailable, you can run the dashboard directly with `python3 server.py`.
+
 Open **http://localhost:1337** (or set `PORT` in `.env`).
 
 ### What’s in the UI


### PR DESCRIPTION
### Motivation
- Ensure contributors can start the Flask + Socket.IO dashboard even when the `zwanski start` CLI shim is not available by documenting a direct fallback command.

### Description
- Add a single-line clarification to `README.md` that shows the fallback startup command `python3 server.py`; this is a documentation-only change to one file.

### Testing
- No automated tests or linters were executed because this change only touches documentation and was intentionally skipped per the project policy for docs-only edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa896796f4832ebb01439c7f2c5bc4)